### PR TITLE
Feature/metrics

### DIFF
--- a/backend/auth-service/build.gradle
+++ b/backend/auth-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 
     implementation 'org.springframework.cloud:spring-cloud-starter-consul-discovery'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {

--- a/backend/auth-service/src/main/java/ru/calendorny/authservice/metric/RegisterUserMetric.java
+++ b/backend/auth-service/src/main/java/ru/calendorny/authservice/metric/RegisterUserMetric.java
@@ -1,0 +1,21 @@
+package ru.calendorny.authservice.metric;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RegisterUserMetric {
+
+    private final Counter registeredUsersCounter;
+
+    public RegisterUserMetric(MeterRegistry registry) {
+        this.registeredUsersCounter = Counter.builder("registered_users_total")
+            .description("Total number of registered users")
+            .register(registry);
+    }
+
+    public void incrementRegisteredUsers() {
+        registeredUsersCounter.increment();
+    }
+}

--- a/backend/auth-service/src/main/java/ru/calendorny/authservice/service/ProfileService.java
+++ b/backend/auth-service/src/main/java/ru/calendorny/authservice/service/ProfileService.java
@@ -9,6 +9,7 @@ import ru.calendorny.authservice.dto.response.UserProfile;
 import ru.calendorny.authservice.entity.Account;
 import ru.calendorny.authservice.entity.Profile;
 import ru.calendorny.authservice.exception.NotFoundException;
+import ru.calendorny.authservice.metric.RegisterUserMetric;
 import ru.calendorny.authservice.repository.AccountRepository;
 import ru.calendorny.authservice.repository.ProfileRepository;
 
@@ -19,6 +20,7 @@ public class ProfileService {
 
     private final AccountRepository accountRepository;
     private final ProfileRepository profileRepository;
+    private final RegisterUserMetric registerUserMetric;
 
     public UserProfile getUserProfile(UUID id) {
         log.debug("Get user profile by id: {}", id);
@@ -39,6 +41,8 @@ public class ProfileService {
         log.debug("Save user profile: {}", userProfileEdit);
         Profile profile = convertToProfile(userProfileEdit, id);
         profileRepository.save(profile);
+        registerUserMetric.incrementRegisteredUsers();
+
     }
 
     private Profile convertToProfile(UserProfileEdit userProfileEdit, UUID id) {

--- a/backend/auth-service/src/main/resources/application.yaml
+++ b/backend/auth-service/src/main/resources/application.yaml
@@ -25,7 +25,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info
+        include: health, info, prometheus
 
 server:
   port: 8080

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -198,10 +198,41 @@ services:
     networks:
       - backend
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - prometheus-data:/prometheus
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+    depends_on:
+      - task-service
+    networks:
+      - backend
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+    networks:
+      - backend
+
 volumes:
   kafka-data:
   task-service-postgres-data:
   db-auth-data:
+  prometheus-data:
+  grafana-data:
 
 networks:
   task-service:

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -209,6 +209,7 @@ services:
     restart: unless-stopped
     depends_on:
       - task-service
+      - auth-service
     networks:
       - backend
 

--- a/backend/prometheus.yml
+++ b/backend/prometheus.yml
@@ -6,3 +6,7 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: ['task-service:8080']
+  - job_name: 'auth-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'auth-service:8080' ]

--- a/backend/prometheus.yml
+++ b/backend/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'task-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['task-service:8080']

--- a/backend/task-service/build.gradle
+++ b/backend/task-service/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 
     implementation 'org.codehaus.janino:janino:3.1.10'
     runtimeOnly 'org.aspectj:aspectjweaver'
+
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {

--- a/backend/task-service/src/main/resources/application.yaml
+++ b/backend/task-service/src/main/resources/application.yaml
@@ -47,7 +47,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info
+        include: health, info, prometheus
 
 task:
   kafka:


### PR DESCRIPTION
Стандартные метрики готовы, нюанс: prometheus надо привязать в grafana как datasource один раз, а потом не сбрасывать volume, чтобы настройки сохранялись (первая статья из теории по метрикам, часть с картинками по графане)

Чтобы привязать свой сервис и собирать с него метрики:

1. установить в application.yml

management:
  endpoints:
    web:
      exposure:
        include:  ... , prometheus

2. добавить зависимость 
    implementation 'io.micrometer:micrometer-registry-prometheus'

3. добавить в prometheus.yml(в корне проекта) данные о вашем сервисе:

  - job_name: 'task-service'
    metrics_path: '/actuator/prometheus'
    static_configs:
      - targets: ['task-service:8080']
